### PR TITLE
STARRY: replace gnulib remote

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gnulib"]
 	path = gnulib
-	url = git://git.savannah.gnu.org/gnulib.git
+	url = https://github.com/coreutils/gnulib.git


### PR DESCRIPTION
The official remote for the gnulib repo (on git.savannah.gnu.org) often fails and triggers failures in our CI builds.  Replacing with the github hosted mirror of the same repo.